### PR TITLE
Merge references with the current uri, so that relative references…

### DIFF
--- a/src/reference.lisp
+++ b/src/reference.lisp
@@ -304,7 +304,7 @@
 
 
 (defun make-reference (reference-string)
-  (let* ((uri (quri:uri reference-string))
+  (let* ((uri (quri:merge-uris reference-string (get-current-uri)))
          (fragment (quri:uri-fragment uri)))
 
     (make-instance 'reference


### PR DESCRIPTION
… will work (or at least work slightly better).

Without this, a schema split over multiple files will (in most cases) get incorrect urls for child schemas.

In the example below, json-schema will try to fetch the child schema through the uri http://localhost:8000/employee.json.

Example:

Parent schema:

```
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "$id": "http://localhost:8000/schemas/department.json",
    "$version": "0.1",
    "title": "department",
    "required": [
        "name", "manager", "employees"
    ],
    "properties": {
        "name": {
            type: "string"
        },
        "manager": {
            "type": "string"
        },
        "employees": {
            "type": "array",
            "items": {
                "$ref": "employee.json"
            }
        }
    }
}
```
Child schema:
```
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "$id": "employee.json",
    "$version": "0.1",
    "title": "employee",
    "required": [
        "name", "role"
    ],
    "properties": {
        "name": {
            "type": "string"
        },
        "role": {
            "type": "string"
        }
    }
}
```
Sample file:
```
{
    "$schema": "http://localhost:8000/schemas/department.json",
    "name": "IT Development",
    "manager": "Manager0",
    "employees": [
        {
            "name": "Developer0",
            "role": "Front-End Developer"
        },
        {
            "name": "Developer1",
            "role": "Back-End Developer",
        },
        {
            "name": "ReleaseManager0",
            "role": "Release Manager"
        }
    ]
}
```


