### PR TITLE
Cached contexts

### DIFF
--- a/src/json-schema.lisp
+++ b/src/json-schema.lisp
@@ -6,7 +6,9 @@
                           :schema-version)
   (:export #:validate
            #:*schema-version*
-           #:schema-version))
+           #:schema-version
+           #:capture-context
+           #:validate-with-context))
 
 (in-package :json-schema)
 
@@ -23,3 +25,28 @@
         (if-let ((errors (validators:validate schema data schema-version)))
           (values nil (mapcar (if pretty-errors-p #'princ-to-string #'identity) errors))
           (values t nil))))))
+
+(defstruct captured-context
+  "Contains all necessary context for validating against a specific schema."
+  (schema nil :type hash-table)
+  (schema-version nil :type keyword)
+  (context nil :type reference:context)
+  (id-fun nil))
+
+(defun capture-context (schema-uri &key (schema-version *schema-version*))
+  (let ((schema (json-schema.parse:parse (dex:get schema-uri :force-string t))))
+    (reference:with-context ((json-schema.reference:get-id-fun-for-draft schema-version))
+      (reference:with-pushed-context (schema)
+        (make-captured-context :schema schema :schema-version schema-version
+                               :context (copy-context json-schema.reference::*context*)
+                               :id-fun json-schema.reference::*id-fun*)))))
+
+(defun validate-with-context (data context &key (pretty-errors-p t))
+  (let ((reference:*context* (captured-context-context context))
+        (reference:*id-fun* (captured-context-id-fun context))
+        (schema (captured-context-schema context))
+        (schema-version (captured-context-schema-version context)))
+    (if-let ((errors (validators:validate schema data schema-version)))
+        (values nil (mapcar (if pretty-errors-p #'princ-to-string #'identity) errors))
+      (values t nil))))
+

--- a/src/reference.lisp
+++ b/src/reference.lisp
@@ -14,14 +14,18 @@
            #:get-ref
            #:with-resolved-ref
            #:*resolve-remote-references*
+           #:*context*
+           #:*id-fun*
+           #:with-pushed-id
+           #:get-id-fun-for-draft
+           #:context
+           #:copy-context
 
            ;; conditions
            #:remote-reference-error
            #:fetching-not-allowed-error
            #:reference-error
-           #:nested-reference-error
-           #:with-pushed-id
-           #:get-id-fun-for-draft))
+           #:nested-reference-error))
 
 (in-package :json-schema.reference)
 
@@ -98,6 +102,10 @@
   (references (make-hash-table :test 'equal) :type hash-table)
   (named-references (make-hash-table :test'equal) :type hash-table))
 
+(defun copy-context (context)
+  (make-context :uri-stack (copy-list (json-schema.reference::context-uri-stack context ))
+                :references (copy-hash-table (json-schema.reference::context-references context))
+                :named-references (copy-hash-table (json-schema.reference::context-named-references context))))
 
 (defun default-id-fun (schema)
   (if (typep schema 'utils:object)


### PR DESCRIPTION
This is an implementation of your idea of "reusable contexts"; I hope it (or something similar) can be added to json-schema.

For a trivial case, validating the same document 100 times, I get a speedup of ~38x if the schema has not been cached, and ~7700x if the schema is already in the cache.

No caching: 7.678 seconds
Caching, context not already in cache: 0.203 seconds
Caching, context already in cache:  0.001 seconds

I'm very happy with (and impressed by) json-schema!