### PR TITLE
Better reporting for one-of schema validation failures

### DIFF
--- a/src/validators.lisp
+++ b/src/validators.lisp
@@ -534,9 +534,15 @@
   (let ((errors-for-schema (loop for sub-schema in sub-schemas
                                  collecting (validate sub-schema data))))
 
-    (condition (some #'null errors-for-schema)
-               "~a was not valid under any given schema."
-               data)
+    (sub-errors (unless (some #'null errors-for-schema)
+                  errors-for-schema)
+                "~a was not valid under any given schema."
+                (if (hash-table-p data)
+                  (format nil "{~{~a~^,~}}"
+                          (loop for k being the hash-keys of data
+                                for n below 10
+                                collect k))
+                  data))
 
     (condition (= 1 (length (remove-if-not #'null errors-for-schema)))
                "~a was valid for more than one given schema."


### PR DESCRIPTION
With this change, validation failures for one-of schemas displays (some of ) the keys for the sub-schema that failed validation, as well as a list of sub-errors in the validation.